### PR TITLE
Update tests for relaxed non-monotonic segmentation

### DIFF
--- a/test/test_detect_breaks.py
+++ b/test/test_detect_breaks.py
@@ -106,6 +106,7 @@ def test_detect_breaks_monotonic(offset, threshold_seconds, reverse):
 
 # Non-monotonic timeseries data
 
+
 @pytest.mark.parametrize("reverse", (False, True))
 @pytest.mark.parametrize("threshold_seconds", [0.1, 1, 2])
 @pytest.mark.parametrize("offset", [-10, -1, 0, 10])

--- a/test/test_detect_breaks.py
+++ b/test/test_detect_breaks.py
@@ -4,59 +4,81 @@ from pyxdf.pyxdf import _detect_breaks
 
 from mock_data_stream import MockStreamData
 
+# Segment at absolute time-intervals exceeding a given threshold. Sequences of
+# identical absolute intervals should be segmented the same regardless of
+# whether they are positive or negative.
+
 # Monotonic timeseries data
 
 
+@pytest.mark.parametrize("reverse", (False, True))
 @pytest.mark.parametrize("seconds", (2, 1))
-def test_detect_no_breaks_seconds(seconds):
+def test_detect_no_breaks_seconds(seconds, reverse):
     time_stamps = list(range(-5, 5))
+    if reverse:
+        time_stamps = list(reversed(time_stamps))
     stream = MockStreamData(time_stamps=time_stamps, tdiff=1)
-    # if diff > seconds -> 0
+    # if abs(diff) > seconds -> 0
     b_breaks = _detect_breaks(stream, threshold_seconds=seconds, threshold_samples=0)
     breaks = np.where(b_breaks)[0]
     assert breaks.size == 0
 
 
+@pytest.mark.parametrize("reverse", (False, True))
 @pytest.mark.parametrize("samples", (2, 1))
-def test_detect_no_breaks_samples(samples):
+def test_detect_no_breaks_samples(samples, reverse):
     time_stamps = list(range(-5, 5))
+    if reverse:
+        time_stamps = list(reversed(time_stamps))
     stream = MockStreamData(time_stamps=time_stamps, tdiff=1)
-    # if diff > samples * tdiff -> 0
+    # if abs(diff) > samples * tdiff -> 0
     b_breaks = _detect_breaks(stream, threshold_seconds=0, threshold_samples=samples)
     breaks = np.where(b_breaks)[0]
     assert breaks.size == 0
 
 
-def test_detect_no_breaks_equal():
+@pytest.mark.parametrize("reverse", (False, True))
+def test_detect_no_breaks_equal(reverse):
     time_stamps = [-2, -2, -1, 0, 0, 1, 2, 2]
+    if reverse:
+        time_stamps = list(reversed(time_stamps))
     stream = MockStreamData(time_stamps=time_stamps, tdiff=1)
-    # if diff < 0 or diff > 1 -> 0
+    # if abs(diff) > 1 -> 0
     b_breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=0)
     breaks = np.where(b_breaks)[0]
     assert breaks.size == 0
 
 
-def test_detect_breaks_seconds():
+@pytest.mark.parametrize("reverse", (False, True))
+def test_detect_breaks_seconds(reverse):
     time_stamps = list(range(-5, 5, 2))
+    if reverse:
+        time_stamps = list(reversed(time_stamps))
     stream = MockStreamData(time_stamps=time_stamps, tdiff=1)
-    # if diff > 1 -> 4
+    # if abs(diff) > 1 -> 4
     b_breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=0)
     breaks = np.where(b_breaks)[0]
     assert breaks.size == len(time_stamps) - 1
 
 
-def test_detect_breaks_samples():
+@pytest.mark.parametrize("reverse", (False, True))
+def test_detect_breaks_samples(reverse):
     time_stamps = list(range(-5, 5, 2))
+    if reverse:
+        time_stamps = list(reversed(time_stamps))
     stream = MockStreamData(time_stamps=time_stamps, tdiff=1)
-    # if diff > 1 -> 4
+    # if abs(diff) > 1 -> 4
     breaks = _detect_breaks(stream, threshold_seconds=0, threshold_samples=1)
     assert breaks.size == len(time_stamps) - 1
 
 
+@pytest.mark.parametrize("reverse", (False, True))
 @pytest.mark.parametrize("threshold_seconds", [0.1, 1, 2])
 @pytest.mark.parametrize("offset", [-10, -1, 0, 10])
-def test_detect_breaks_monotonic(offset, threshold_seconds):
-    time_stamps = [0] + [2, 3, 4, 5] + [8, 9, 10]
+def test_detect_breaks_monotonic(offset, threshold_seconds, reverse):
+    time_stamps = [0] + [2, 3, 4, 5] + [8]
+    if reverse:
+        time_stamps = list(reversed(time_stamps))
     time_stamps = np.array(time_stamps) + offset
     stream = MockStreamData(time_stamps=time_stamps, tdiff=1)
     b_breaks = _detect_breaks(
@@ -66,36 +88,31 @@ def test_detect_breaks_monotonic(offset, threshold_seconds):
     )
     breaks = np.where(b_breaks)[0]
     if threshold_seconds == 0.1:
-        # if diff > 0.1 -> 8
+        # if abs(diff) > 0.1 -> 5
         assert breaks.size == len(time_stamps) - 1
     elif threshold_seconds == 1:
-        # if diff > 1 -> 2
+        # if abs(diff) > 1 -> 2
         assert breaks.size == 2
         assert breaks[0] == 0
         assert breaks[1] == 4
     elif threshold_seconds == 2:
-        # if diff > 2 -> 1
+        # if abs(diff) > 2 -> 1
         assert breaks.size == 1
-        assert breaks[0] == 4
+        if reverse:
+            assert breaks[0] == 0
+        else:
+            assert breaks[0] == 4
 
 
-# Non-monotonic timeseries data: segment at negative time-intervals or positive
-# time-intervals exceeding threshold
+# Non-monotonic timeseries data
 
-
-def test_detect_breaks_reverse():
-    time_stamps = list(reversed(range(-5, 5)))
-    stream = MockStreamData(time_stamps=time_stamps, tdiff=1)
-    # if diff < 0 -> 9
-    b_breaks = _detect_breaks(stream, threshold_seconds=1, threshold_samples=0)
-    breaks = np.where(b_breaks)[0]
-    assert breaks.size == len(time_stamps) - 1
-
-
+@pytest.mark.parametrize("reverse", (False, True))
 @pytest.mark.parametrize("threshold_seconds", [0.1, 1, 2])
 @pytest.mark.parametrize("offset", [-10, -1, 0, 10])
-def test_detect_breaks_non_monotonic(offset, threshold_seconds):
+def test_detect_breaks_non_monotonic(offset, threshold_seconds, reverse):
     time_stamps = [3] + [0, 1, 2] + [4, 5, 6] + [5]
+    if reverse:
+        time_stamps = list(reversed(time_stamps))
     time_stamps = np.array(time_stamps) + offset
     stream = MockStreamData(time_stamps=time_stamps, tdiff=1)
     b_breaks = _detect_breaks(
@@ -105,16 +122,21 @@ def test_detect_breaks_non_monotonic(offset, threshold_seconds):
     )
     breaks = np.where(b_breaks)[0]
     if threshold_seconds == 0.1:
-        # if diff < 0 or diff > 0.1 -> 8
+        # if abs(diff) > 0.1 -> 7
         assert breaks.size == len(time_stamps) - 1
     elif threshold_seconds == 1:
-        # if diff < 0 or diff > 1 -> 3
-        assert breaks.size == 3
-        assert breaks[0] == 0
-        assert breaks[1] == 3
-        assert breaks[2] == 6
-    elif threshold_seconds == 2:
-        # if diff < 0 or diff > 2 -> 2
+        # if abs(diff) > 1 -> 2
         assert breaks.size == 2
-        assert breaks[0] == 0
-        assert breaks[1] == 6
+        if reverse:
+            assert breaks[0] == 3
+            assert breaks[1] == 6
+        else:
+            assert breaks[0] == 0
+            assert breaks[1] == 3
+    elif threshold_seconds == 2:
+        # if abs(diff) > 2 -> 1
+        assert breaks.size == 1
+        if reverse:
+            assert breaks[0] == 6
+        else:
+            assert breaks[0] == 0

--- a/test/test_jitter_removal.py
+++ b/test/test_jitter_removal.py
@@ -79,14 +79,15 @@ def test_jitter_removal_two_segments_non_monotonic(segments, t_starts):
 def test_jitter_removal_glitch():
     srate = 1
     tdiff = 1
-    time_stamps = [1, 2, 3, 4, 6, 5, 7, 8, 9, 10]
+    time_stamps = [1, 2, 3, 4] + [6, 5] + [7, 8, 9, 10]
     streams = {1: MockStreamData(time_stamps=time_stamps, srate=srate, tdiff=tdiff)}
     _jitter_removal(streams, threshold_seconds=1, threshold_samples=1)
     stream = streams[1]
-    assert stream.segments == [(0, 3), (4, 4), (5, 5), (6, 9)]
+    assert stream.segments == [(0, 3), (4, 5), (6, 9)]
     np.testing.assert_allclose(stream.time_stamps, time_stamps)
     np.testing.assert_equal(stream.time_series[:, 0], time_stamps)
-    np.testing.assert_allclose(stream.effective_srate, srate)
+    # FIXME: This will fail if we do not always segment at negative time
+    # intervals: the duration of segment [6, 5] is -1.
     np.testing.assert_allclose(stream.effective_srate, srate)
 
 


### PR DESCRIPTION
`test_jitter_removal_glitch` still fails because segmenting with `abs(diffs)` removes the guarantee of non-negative segment durations